### PR TITLE
Add network flow log endpoint and re-organize examples

### DIFF
--- a/examples/acl-example.py
+++ b/examples/acl-example.py
@@ -23,19 +23,29 @@ from tailscale_agent.tailscale_agent import Tailscale
 BASE_URL = 'https://api.tailscale.com/api/v2'
 
 # Can be found/generated here: https://login.tailscale.com/admin/settings/keys
+# If you're using an OAuth client set this to None.
 API_KEY = 'YOUR_API_KEY'
+
+# If you're using an OAuth client, you can set the ID and secret here. Your location may vary.
+# You will also need to uncomment the 'client.get_oauth_token' code below.
+# OAUTH_CLIENT_ID = os.getenv('tailscale_oauth_client_id')
+# OAUTH_CLIENT_SECRET = os.getenv('tailscale_oauth_client_secret')
 
 # The name of the tailnet upon which you wish to operate.
 # Can be found in the upper left hand corner of your TailScale dashboard
 # If you signed up with a gmail account, for example, it will likely be
 # your full gmail address
-TAILNET = 'YOUR_TAILNET_NAME'
+TAILNET = os.getenv('tailscale_tailnet')
+
 
 # JSON file with the ACLs you wish to validate/update
 ACL_JSON_FILE = os.path.abspath("./test.json")
 
 # Create the tailscale client using the values from above
 client = Tailscale(API_KEY, BASE_URL, TAILNET)
+
+# If you're using an Oauth Client values, then this will cause the client to grab a scoped token
+# client.get_oauth_token(OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET)
 
 print(client)
 

--- a/examples/logs-example.py
+++ b/examples/logs-example.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import json
+import os
+import sys
+
+from tailscale_agent.tailscale_agent import Tailscale
+
+# Base URL for the API. The default should work unless
+# you have some special setup
+BASE_URL = 'https://api.tailscale.com/api/v2'
+
+# Name of your tailnet, or grab it from the environment
+TAILNET = os.getenv('tailscale_tailnet')
+
+# Can be found/generated here: https://login.tailscale.com/admin/settings/keys
+# If you're using an OAuth client set this to None.
+API_KEY = 'YOUR_API_KEY'
+
+# If you're using an OAuth client, you can set the ID and secret here. Your location may vary.
+# You will also need to uncomment the 'client.get_oauth_token' code below.
+OAUTH_CLIENT_ID = os.getenv('tailscale_oauth_client_id')
+OAUTH_CLIENT_SECRET = os.getenv('tailscale_oauth_client_secret')
+
+client = Tailscale(API_KEY, BASE_URL, TAILNET)
+# If you're using an Oauth Client values, then this will cause the client to grab a scoped token
+client.get_oauth_token(OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET)
+
+# Grab the network-logs via the 'network-logs' endpoint and print them
+network_logs = client.get_network_logs("2023-05-12T14:29:00Z", "2023-05-12T14:29:10Z")
+print(json.dumps(network_logs.json(), indent=2))
+
+# Grab the audit logs and via the 'logs' endpoint and print them
+# Deprecated but left for now for backward compat
+# audit_logs = client.get_logs("2023-05-12T16:58:00Z", "2023-05-12T17:00:00Z")
+# New preferred way
+audit_logs = client.get_audit_logs("2023-05-12T16:58:00Z", "2023-05-12T17:00:00Z")
+print(json.dumps(audit_logs.json(), indent=2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tailscale_agent"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python Bindings for the TailScal API"
 authors = ["Kevin Bringard <kevin.bringard@phreesia.com>"]
 readme = "README.md"

--- a/tailscale_agent/tailscale_agent.py
+++ b/tailscale_agent/tailscale_agent.py
@@ -377,8 +377,9 @@ class Tailscale:
 
         return(response)
 
+
     # Logs related methods
-    def get_logs(self, starttime, endtime):
+    def get_audit_logs(self, starttime, endtime):
         """
         Get Audit logs from the logs/ API endpoint.
 
@@ -394,6 +395,35 @@ class Tailscale:
         """
 
         url = f'{self._base_url}/tailnet/{self._tailnet}/logs?start={starttime}&end={endtime}'
+
+        response = requests.get(url, auth=self._auth, headers=self._headers)
+
+        return response
+
+    # Create an alias for backward compatibility
+    # This will be deprecated at some point in the future
+    get_logs = get_audit_logs
+
+
+    def get_network_logs(self, starttime, endtime):
+        """
+
+        Get Network Audit logs from the network-logs/ API endpoint.
+
+        You *must* specify a start time and an end time to scope the query, and they
+        *must* be in the format "1990-01-01T00:00:00Z" or the API will reject it as
+        invalid
+
+        You must also have network flow logs enabled in the logs section of your tailnet's admin console
+
+        :param starttime: Start time in ISO-8601 format. For example: 1990-01-01T00:00:00Z
+        :param endtime: End time in ISO-8601 format. For example: 1991-01-01T00:00:00Z
+
+        :return: requests response object, or None if the date strings are invalid
+
+        """
+
+        url = f'{self._base_url}/tailnet/{self._tailnet}/network-logs?start={starttime}&end={endtime}'
 
         response = requests.get(url, auth=self._auth, headers=self._headers)
 
@@ -431,8 +461,13 @@ class Tailscale:
         if not client_embed:
             return response
 
-        access_token = response.json()['access_token']
-        self._api_key = access_token
-        self._auth = HTTPBasicAuth(access_token, '')
+        try:
+            access_token = response.json()['access_token']
+            self._api_key = access_token
+            self._auth = HTTPBasicAuth(access_token, '')
+        except:
+            print ('I was not able to set the access token.')
+            print ('Please ensure you have your OAuth client set '
+                  'correctly and it has the necessary permissions.')
 
         return response


### PR DESCRIPTION
Tailscale added (as beta) network flow logs. If you enable this you can now query those logs via the agent here. See the updated examples for how to do this.

It's also worth noting: as of this writing there is no OAuth scope specific to logging endpoints, so if you're using OAuth you need to grant the "All" permission to the client. I have opened a case with Tailscale to ask if/when they'd have a timeline on getting that added.

Please note the get_logs client method is currently aliased, but will be deprecated in a future version. Please use get_audit_logs moving forward